### PR TITLE
Safely return from module cleanup if currentSpec does not exist

### DIFF
--- a/angular-mocks.js
+++ b/angular-mocks.js
@@ -2748,6 +2748,7 @@ angular.mock.$RootScopeDecorator = ['$delegate', function($delegate) {
   };
 
   module.$$cleanup = function() {
+    if (!currentSpec) return;
     var injector = currentSpec.$injector;
 
     annotatedFunctions.forEach(function(fn) {


### PR DESCRIPTION
ie. if testing something other than an Angular module.